### PR TITLE
Give Leonardo-type arduinos 2048 storage

### DIFF
--- a/logic_analyzer.ino
+++ b/logic_analyzer.ino
@@ -156,6 +156,9 @@ void captureInline2mhz(void);
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #define DEBUG_CAPTURE_SIZE 7168
 #define CAPTURE_SIZE 7168
+#elif defined(__AVR_ATmega32U4__)
+#define DEBUG_CAPTURE_SIZE 2048
+#define CAPTURE_SIZE 2048
 #elif defined(__AVR_ATmega328P__)
 #define DEBUG_CAPTURE_SIZE 1024
 #define CAPTURE_SIZE 1024


### PR DESCRIPTION
The atmega 32U4 has 2.5K of storage. Let's use it!